### PR TITLE
WIP: py 3.6 enable bitcode, bump numpy to 1.16.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,9 +180,9 @@ SDK-$1=$$(basename $1)
 SDK_ROOT-$1=$$(shell xcrun --sdk $$(SDK-$1) --show-sdk-path)
 CC-$1=xcrun --sdk $$(SDK-$1) clang \
 	-arch $$(ARCH-$1) \
-	--sysroot=$$(SDK_ROOT-$1) \
+	--sysroot $$(SDK_ROOT-$1) \
 	$$(CFLAGS-$2) $$(CFLAGS-$1)
-LDFLAGS-$1=-arch $$(ARCH-$1) -isysroot=$$(SDK_ROOT-$1)
+LDFLAGS-$1=-arch $$(ARCH-$1) -isysroot $$(SDK_ROOT-$1)
 
 OPENSSL_DIR-$1=build/$2/openssl-$(OPENSSL_VERSION)-$1
 BZIP2_DIR-$1=build/$2/bzip2-$(BZIP2_VERSION)-$1

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ CFLAGS-macOS=-mmacosx-version-min=$(MACOSX_DEPLOYMENT_TARGET)
 
 # iOS targets
 TARGETS-iOS=iphonesimulator.x86_64 iphoneos.arm64
-CFLAGS-iOS=-mios-version-min=7.0
+CFLAGS-iOS=-mios-version-min=11.0
 CFLAGS-iphoneos.arm64=-fembed-bitcode
 
 # tvOS targets

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ CFLAGS-macOS=-mmacosx-version-min=$(MACOSX_DEPLOYMENT_TARGET)
 TARGETS-iOS=iphonesimulator.x86_64 iphoneos.arm64
 CFLAGS-iOS=-mios-version-min=11.0
 CFLAGS-iphoneos.arm64=-fembed-bitcode
+CFLAGS-iphonesimulator.x86_64=-fembed-bitcode
 
 # tvOS targets
 TARGETS-tvOS=appletvsimulator.x86_64 appletvos.arm64

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,8 @@ clean-bzip2:
 # Download original BZip2 source code archive.
 downloads/bzip2-$(BZIP2_VERSION).tgz:
 	mkdir -p downloads
-	if [ ! -e downloads/bzip2-$(BZIP2_VERSION).tgz ]; then curl --fail -L http://www.bzip.org/$(BZIP2_VERSION)/bzip2-$(BZIP2_VERSION).tar.gz -o downloads/bzip2-$(BZIP2_VERSION).tgz; fi
+	#if [ ! -e downloads/bzip2-$(BZIP2_VERSION).tgz ]; then curl --fail -L http://www.bzip.org/$(BZIP2_VERSION)/bzip2-$(BZIP2_VERSION).tar.gz -o downloads/bzip2-$(BZIP2_VERSION).tgz; fi
+		if [ ! -e downloads/bzip2-$(BZIP2_VERSION).tgz ]; then curl --fail -L https://fossies.org/linux/misc/bzip2-$(BZIP2_VERSION).tar.gz -o downloads/bzip2-$(BZIP2_VERSION).tgz; fi
 
 ###########################################################################
 # XZ (LZMA)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ PROJECT_DIR=$(shell pwd)
 
 BUILD_NUMBER=7
 
-MACOSX_DEPLOYMENT_TARGET=10.8
+MACOSX_DEPLOYMENT_TARGET=10.14
 
 # Version of packages that will be compiled by this meta-package
 PYTHON_VERSION=3.6.6

--- a/patch/numpy/Makefile.numpy
+++ b/patch/numpy/Makefile.numpy
@@ -38,13 +38,6 @@ build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER)/libpymath.a: build/$2/packag
 
 build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER)/libnumpy.a: build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER)/libpymath.a
 	cd build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER) && \
-		CC="$$(NUMPY-CC-$1)" \
-		CFLAGS="$$(NUMPY-CFLAGS-$1)" \
-		BASECFLAGS="" \
-		LDSHARED="$$(NUMPY-LDSHARED-$1)" \
-		LDLIB="$$(NUMPY-LDLIB-$1)" \
-		$(NUMPY_CONFIG) \
-		_PYTHON_HOST_PLATFORM=$1 \
 		xcrun --sdk $$(SDK-$1) ar -q libnumpy.a `find . -name "*.o"`
 
 numpy-$1: build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER)/libnumpy.a

--- a/patch/numpy/Makefile.numpy
+++ b/patch/numpy/Makefile.numpy
@@ -2,7 +2,7 @@
 # NumPy
 ###########################################################################
 
-NUMPY_VERSION=1.14.1
+NUMPY_VERSION=1.16.3
 NUMPY_CONFIG=BLAS=None LAPACK=None ATLAS=None
 
 # Download original numpy source code archive.

--- a/patch/numpy/Makefile.numpy
+++ b/patch/numpy/Makefile.numpy
@@ -11,11 +11,10 @@ downloads/numpy-$(NUMPY_VERSION).tgz:
 	if [ ! -e downloads/numpy-$(NUMPY_VERSION).tgz ]; then curl --fail -L https://github.com/numpy/numpy/releases/download/v$(NUMPY_VERSION)/numpy-$(NUMPY_VERSION).tar.gz -o downloads/numpy-$(NUMPY_VERSION).tgz; fi
 
 define build-numpy-target
-NUMPY-CFLAGS-$1=$$(CFLAGS-$2)
+NUMPY-CFLAGS-$1=$$(CFLAGS-$1)
 NUMPY-CC-$1=xcrun --sdk $$(SDK-$1) clang \
 	-arch $$(ARCH-$1) \
-	--sysroot=$$(SDK_ROOT-$1) \
-	$$(NUMPY_CFLAGS-$1)
+	--sysroot $$(SDK_ROOT-$1) \
 
 build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER)/libpymath.a: build/$2/packages/numpy
 	cd build/$2/packages/numpy && \
@@ -23,7 +22,7 @@ build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER)/libpymath.a: build/$2/packag
 		CFLAGS="$$(NUMPY-CFLAGS-$1)" \
 		$(NUMPY_CONFIG) \
 		_PYTHON_HOST_PLATFORM=$1 \
-		$(HOST_PYTHON) setup.py build_ext
+		$(HOST_PYTHON) setup.py --verbose --no-user-cfg build_ext
 
 build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER)/libnumpy.a: build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER)/libpymath.a
 	cd build/$2/packages/numpy/build/temp.$1-$(PYTHON_VER) && \

--- a/patch/numpy/Makefile.numpy
+++ b/patch/numpy/Makefile.numpy
@@ -77,7 +77,20 @@ dist/$1/libnumpy.a: $(foreach target,$(TARGETS-$1),numpy-$(target))
 	xcrun lipo -create -output dist/$1/libnpysort.a $(foreach target,$(TARGETS-$1),build/$1/packages/numpy/build/temp.$(target)-$(PYTHON_VER)/libnpysort.a)
 	xcrun lipo -create -output dist/$1/libnumpy.a $(foreach target,$(TARGETS-$1),build/$1/packages/numpy/build/temp.$(target)-$(PYTHON_VER)/libnumpy.a)
 
-numpy-$1: dist/$1/libnumpy.a
+dist/$1/app_packages/numpy/: downloads/numpy-$(NUMPY_VERSION).tgz
+	mkdir -p dist/$1/app_packages/
+	cp -r build/$1/packages/numpy/numpy dist/$1/app_packages/
+	find build/$1/packages/numpy//build/ -name '__config__.py' -exec cp {} dist/$1/app_packages/numpy  \;
+	
+	# Remove unneeded files
+	# Remove module mtrand, it's provided by fat lib
+	rm -rf dist/$1/app_packages/numpy/random/mtrand
+	find dist/$1/app_packages/numpy/ -name tests -delete
+	find dist/$1/app_packages/numpy/ -name __pycache__ -delete
+	find dist/$1/app_packages/numpy/ -name *.pyc -delete
+	
+
+numpy-$1: dist/$1/libnumpy.a dist/$1/app_packages/numpy/
 
 endif
 endef

--- a/patch/numpy/Makefile.numpy
+++ b/patch/numpy/Makefile.numpy
@@ -10,9 +10,6 @@ downloads/numpy-$(NUMPY_VERSION).tgz:
 	mkdir -p downloads
 	if [ ! -e downloads/numpy-$(NUMPY_VERSION).tgz ]; then curl --fail -L https://github.com/numpy/numpy/releases/download/v$(NUMPY_VERSION)/numpy-$(NUMPY_VERSION).tar.gz -o downloads/numpy-$(NUMPY_VERSION).tgz; fi
 
-# NUMPY-LDSHARED-iphonesimulator.x86_64=xcrun --sdk 'iphonesimulator' clang \
-#	-arch x86_64 -Wall \
-# --sysroot $$(SDK_ROOT-$1) -v -bundle -undefined dynamic_lookup
 define build-numpy-target
 NUMPY-CFLAGS-$1=$$(CFLAGS-$1)
 NUMPY-CC-$1=xcrun --sdk $$(SDK-$1) clang \

--- a/patch/numpy/README.rst
+++ b/patch/numpy/README.rst
@@ -43,8 +43,7 @@ Adding NumPy to your iOS project
                "class NumpyImporter(object):\n" \
                "    def find_module(self, fullname, mpath=None):\n" \
                "        if fullname in (" \
-               "                    'numpy.core.multiarray', " \
-               "                    'numpy.core.umath', " \
+               '                    'numpy.core._multiarray_umath', " \
                "                    'numpy.fft.fftpack_lite', " \
                "                    'numpy.linalg._umath_linalg', " \
                "                    'numpy.linalg.lapack_lite', " \
@@ -67,8 +66,7 @@ Adding NumPy to your iOS project
 5. Add the following external function declarations to the file that
    configures your Python enviroment::
 
-       extern PyMODINIT_FUNC PyInit_multiarray(void);
-       extern PyMODINIT_FUNC PyInit_umath(void);
+       extern PyMODINIT_FUNC PyInit__multiarray_umath(void);
        extern PyMODINIT_FUNC PyInit_fftpack_lite(void);
        extern PyMODINIT_FUNC PyInit__umath_linalg(void);
        extern PyMODINIT_FUNC PyInit_lapack_lite(void);
@@ -76,8 +74,7 @@ Adding NumPy to your iOS project
 
 6. Add the following function calls *before* invoking ``Py_Initialize()``::
 
-       PyImport_AppendInittab("__numpy_core_multiarray", &PyInit_multiarray);
-       PyImport_AppendInittab("__numpy_core_umath", &PyInit_umath);
+       PyImport_AppendInittab("__numpy_core_multiarray", &PyInit__multiarray_umath);
        PyImport_AppendInittab("__numpy_fft_fftpack_lite", &PyInit_fftpack_lite);
        PyImport_AppendInittab("__numpy_linalg__umath_linalg", &PyInit__umath_linalg);
        PyImport_AppendInittab("__numpy_linalg_lapack_lite", &PyInit_lapack_lite);
@@ -111,8 +108,7 @@ folder in the Xcode project) will look something like this::
     }
 
 
-    extern PyMODINIT_FUNC PyInit_multiarray(void);
-    extern PyMODINIT_FUNC PyInit_umath(void);
+    extern PyMODINIT_FUNC PyInit__multiarray_umath(void);
     extern PyMODINIT_FUNC PyInit_fftpack_lite(void);
     extern PyMODINIT_FUNC PyInit__umath_linalg(void);
     extern PyMODINIT_FUNC PyInit_lapack_lite(void);
@@ -136,8 +132,7 @@ folder in the Xcode project) will look something like this::
             tmp_path = [NSString stringWithFormat:@"TMP=%@/tmp", resourcePath, nil];
             putenv((char *)[tmp_path UTF8String]);
 
-            PyImport_AppendInittab("__numpy_core_multiarray", &PyInit_multiarray);
-            PyImport_AppendInittab("__numpy_core_umath", &PyInit_umath);
+            PyImport_AppendInittab("__numpy_core__multiarray_umath", &PyInit__multiarray_umath);
             PyImport_AppendInittab("__numpy_fft_fftpack_lite", &PyInit_fftpack_lite);
             PyImport_AppendInittab("__numpy_linalg__umath_linalg", &PyInit__umath_linalg);
             PyImport_AppendInittab("__numpy_linalg_lapack_lite", &PyInit_lapack_lite);

--- a/patch/numpy/README.rst
+++ b/patch/numpy/README.rst
@@ -22,7 +22,7 @@ Adding NumPy to your iOS project
      containing the static fat binary libraries needed to support the Python
      code.
 
-2. Copy the contents of `dist/app_packages` into your project's `site_packages`
+2. Copy the contents of `dist/app_packages` or `dist/{iOS/watchOS/tvOS}/app_packages` into your project's `site_packages`
    or `app_packages` directory. This will make the Python library available to
    your project.
 

--- a/patch/numpy/numpy.patch
+++ b/patch/numpy/numpy.patch
@@ -1,6 +1,21 @@
+diff -Nru numpy-1.16.3/numpy/core/setup.py numpy/numpy/core/setup.py
+--- numpy-1.16.3/numpy/core/setup.py  2019-04-21 20:54:37.000000000 +0200
++++ numpy/numpy/core/setup.py 2019-05-06 15:02:09.000000000 +0200
+@@ -68,10 +68,7 @@
+ 
+ def pythonlib_dir():
+     """return path where libpython* is."""
+-    if sys.platform == 'win32':
+-        return os.path.join(sys.prefix, "libs")
+-    else:
+-        return get_config_var('LIBDIR')
++    return get_config_var('LDLIB')
+ 
+ def is_npy_no_signal():
+     """Return True if the NPY_NO_SIGNAL symbol must be defined in configuration
 diff -Nru numpy-1.16.3/numpy/core/src/common/npy_config.h numpy/numpy/core/src/common/npy_config.h
 --- numpy-1.16.3/numpy/core/src/common/npy_config.h 2019-02-22 01:33:41.000000000 +0100
-+++ numpy/numpy/core/src/common/npy_config.h    2019-04-26 16:36:26.000000000 +0200
++++ numpy/numpy/core/src/common/npy_config.h  2019-04-26 16:36:26.000000000 +0200
 @@ -6,6 +6,17 @@
  #include "numpy/npy_cpu.h"
  #include "numpy/npy_os.h"
@@ -21,7 +36,7 @@ diff -Nru numpy-1.16.3/numpy/core/src/common/npy_config.h numpy/numpy/core/src/c
  /* Disable broken Sun Workshop Pro math functions */
 diff -Nru numpy-1.16.3/numpy/core/src/common/npy_fpmath.h numpy/numpy/core/src/common/npy_fpmath.h
 --- numpy-1.16.3/numpy/core/src/common/npy_fpmath.h 2019-02-22 01:33:41.000000000 +0100
-+++ numpy/numpy/core/src/common/npy_fpmath.h    2019-04-26 17:14:16.000000000 +0200
++++ numpy/numpy/core/src/common/npy_fpmath.h  2019-04-26 17:14:16.000000000 +0200
 @@ -15,7 +15,9 @@
        defined(HAVE_LDOUBLE_INTEL_EXTENDED_12_BYTES_LE) || \
        defined(HAVE_LDOUBLE_MOTOROLA_EXTENDED_12_BYTES_BE) || \
@@ -33,3 +48,18 @@ diff -Nru numpy-1.16.3/numpy/core/src/common/npy_fpmath.h numpy/numpy/core/src/c
      #error No long double representation defined
  #endif
  
+diff -Nru numpy-1.16.3/numpy/distutils/ccompiler.py numpy/numpy/distutils/ccompiler.py
+--- numpy-1.16.3/numpy/distutils/ccompiler.py 2019-04-21 20:06:28.000000000 +0200
++++ numpy/numpy/distutils/ccompiler.py  2019-05-06 15:09:18.000000000 +0200
+@@ -400,9 +400,9 @@
+         for macro in cmd.undef:
+             self.undefine_macro(macro)
+     if allow('libraries'):
+-        self.set_libraries(self.libraries + cmd.libraries)
++        self.set_libraries(self.libraries + ["python3.6m", "ssl", "crypto", "bz2", "sqlite3", "z", "lzma", "stdc++", "c++"] + cmd.libraries)
+     if allow('library_dirs'):
+-        self.set_library_dirs(self.library_dirs + cmd.library_dirs)
++        self.set_library_dirs(self.library_dirs + [os.environ['LDLIB']] + cmd.library_dirs)
+     if allow('rpath'):
+         self.set_runtime_library_dirs(cmd.rpath)
+     if allow('link_objects'):

--- a/patch/numpy/numpy.patch
+++ b/patch/numpy/numpy.patch
@@ -63,3 +63,15 @@ diff -Nru numpy-1.16.3/numpy/distutils/ccompiler.py numpy/numpy/distutils/ccompi
      if allow('rpath'):
          self.set_runtime_library_dirs(cmd.rpath)
      if allow('link_objects'):
+diff -Nru numpy-1.16.3/numpy/random/__init__.py numpy/numpy/random/__init__.py
+--- numpy-1.16.3/numpy/random/__init__.py 2019-02-22 01:33:42.000000000 +0100
++++ numpy/numpy/random/__init__.py  2019-05-06 16:37:28.000000000 +0200
+@@ -140,7 +140,7 @@
+ 
+ with warnings.catch_warnings():
+     warnings.filterwarnings("ignore", message="numpy.ndarray size changed")
+-    from .mtrand import *
++    from numpy.random.mtrand import *
+ 
+ # Some aliases:
+ ranf = random = sample = random_sample

--- a/patch/numpy/numpy.patch
+++ b/patch/numpy/numpy.patch
@@ -117,18 +117,25 @@ diff -Nru numpy-1.14.1/numpy/linalg/lapack_lite/f2c.h numpy/numpy/linalg/lapack_
  typedef int integer;
  typedef char *address;
  typedef short int shortint;
---- numpy-1.14.1/numpy/core/src/private/npy_config.h   2018-10-20 17:29:21.000000000 +0200
-+++ numpy/numpy/core/src/private/npy_config copy.h  2018-10-20 17:31:20.000000000 +0200
-@@ -91,7 +91,7 @@
- #if defined(HAVE_POWL) && defined(NPY_OS_DARWIN)
- #undef HAVE_POWL
- #endif
--
+--- numpy-1.14.1/numpy/core/src/private/npy_config.h   2018-10-20 19:30:37.000000000 +0200
++++ numpy/numpy/core/src/private/npy_config.h  2018-10-20 20:13:35.000000000 +0200
+@@ -6,6 +6,15 @@
+ #include "numpy/npy_cpu.h"
+ #include "numpy/npy_os.h"
+ 
++#undef HAVE_ATTRIBUTE_OPTIMIZE_UNROLL_LOOPS
++#undef HAVE_ATTRIBUTE_OPTIMIZE_OPT_3
++#undef HAVE_ATTRIBUTE_TARGET_AVX
++#undef HAVE_ATTRIBUTE_TARGET_AVX2
++#undef HAVE_XMMINTRIN_H
++#undef HAVE_EMMINTRIN_H
++#undef HAVE___BUILTIN_CPU_SUPPORTS
 +#undef HAVE_FEATURES_H
- /* Disable broken gnu trig functions */
- #if defined(HAVE_FEATURES_H)
- #include <features.h>
---- numpy-1.14.1//numpy/core/src/private/npy_fpmath.h   2018-02-05 02:21:37.000000000 +0100
++
+ /*
+  * largest alignment the copy loops might require
+  * required as string, void and complex types might get copied using larger
+--- numpy-1.14.1/numpy/core/src/private/npy_fpmath.h   2018-02-05 02:21:37.000000000 +0100
 +++ numpy/numpy/core/src/private/npy_fpmath.h  2018-10-20 18:59:59.000000000 +0200
 @@ -44,7 +44,8 @@
        defined(HAVE_LDOUBLE_INTEL_EXTENDED_12_BYTES_LE) || \

--- a/patch/numpy/numpy.patch
+++ b/patch/numpy/numpy.patch
@@ -75,7 +75,7 @@ diff -Nru numpy-1.14.1/numpy/linalg/lapack_lite/f2c.h numpy/numpy/linalg/lapack_
  typedef short int shortint;
 --- numpy-1.14.1/numpy/core/src/private/npy_config.h   2018-10-20 19:30:37.000000000 +0200
 +++ numpy/numpy/core/src/private/npy_config.h  2018-10-20 20:13:35.000000000 +0200
-@@ -6,6 +6,15 @@
+@@ -6,6 +6,17 @@
  #include "numpy/npy_cpu.h"
  #include "numpy/npy_os.h"
  
@@ -87,6 +87,8 @@ diff -Nru numpy-1.14.1/numpy/linalg/lapack_lite/f2c.h numpy/numpy/linalg/lapack_
 +#undef HAVE_EMMINTRIN_H
 +#undef HAVE___BUILTIN_CPU_SUPPORTS
 +#undef HAVE_FEATURES_H
++#undef HAVE_SYS_ENDIAN_H
++#undef HAVE_ENDIAN_H
 +
  /*
   * largest alignment the copy loops might require

--- a/patch/numpy/numpy.patch
+++ b/patch/numpy/numpy.patch
@@ -128,3 +128,14 @@ diff -Nru numpy-1.14.1/numpy/linalg/lapack_lite/f2c.h numpy/numpy/linalg/lapack_
  /* Disable broken gnu trig functions */
  #if defined(HAVE_FEATURES_H)
  #include <features.h>
+--- numpy-1.14.1//numpy/core/src/private/npy_fpmath.h   2018-02-05 02:21:37.000000000 +0100
++++ numpy/numpy/core/src/private/npy_fpmath.h  2018-10-20 18:59:59.000000000 +0200
+@@ -44,7 +44,8 @@
+       defined(HAVE_LDOUBLE_INTEL_EXTENDED_12_BYTES_LE) || \
+       defined(HAVE_LDOUBLE_MOTOROLA_EXTENDED_12_BYTES_BE) || \
+       defined(HAVE_LDOUBLE_DOUBLE_DOUBLE_BE) || \
+-      defined(HAVE_LDOUBLE_DOUBLE_DOUBLE_LE))
++      defined(HAVE_LDOUBLE_DOUBLE_DOUBLE_LE) ||\
++      defined(__aarch64__)) /* Cross compiling for ARM64 (which has long double support) on macOS */
+     #error No long double representation defined
+ #endif

--- a/patch/numpy/numpy.patch
+++ b/patch/numpy/numpy.patch
@@ -1,80 +1,6 @@
-diff -Nru numpy-1.14.1/numpy/_build_utils/apple_accelerate.py numpy/numpy/_build_utils/apple_accelerate.py
---- numpy-1.14.1/numpy/_build_utils/apple_accelerate.py	2018-02-05 09:21:37.000000000 +0800
-+++ numpy/numpy/_build_utils/apple_accelerate.py	2018-03-04 13:26:52.000000000 +0800
-@@ -8,8 +8,13 @@
- 
- def uses_accelerate_framework(info):
-     """ Returns True if Accelerate framework is used for BLAS/LAPACK """
-+    # If we're not building on Darwin (macOS), don't use accelerate
-     if sys.platform != "darwin":
-         return False
-+    # If we're building on macOS, but targeting a different platform,
-+    # don't use accelerate.
-+    if os.getenv('_PYTHON_HOST_PLATFORM', None):
-+        return False
-     r_accelerate = re.compile("Accelerate")
-     extra_link_args = info.get('extra_link_args', '')
-     for arg in extra_link_args:
-diff -Nru numpy-1.14.1/numpy/core/src/multiarray/strfuncs.c numpy/numpy/core/src/multiarray/strfuncs.c
---- numpy-1.14.1/numpy/core/src/multiarray/strfuncs.c	2018-02-20 07:16:17.000000000 +0800
-+++ numpy/numpy/core/src/multiarray/strfuncs.c	2018-03-04 13:26:52.000000000 +0800
-@@ -41,7 +41,7 @@
-  * XXX we do this in multiple places; time for a string library?
-  */
- static char *
--extend(char **strp, Py_ssize_t n, Py_ssize_t *maxp)
-+extend_str(char **strp, Py_ssize_t n, Py_ssize_t *maxp)
- {
-     char *str = *strp;
-     Py_ssize_t new_cap;
-@@ -71,7 +71,7 @@
-     npy_intp i, N, ret = 0;
- 
- #define CHECK_MEMORY do {                           \
--        if (extend(string, *n, max_n) == NULL) {    \
-+        if (extend_str(string, *n, max_n) == NULL) {    \
-             ret = -1;                               \
-             goto end;                               \
-         }                                           \
-diff -Nru numpy-1.14.1/numpy/distutils/system_info.py numpy/numpy/distutils/system_info.py
---- numpy-1.14.1/numpy/distutils/system_info.py	2018-02-21 01:46:17.000000000 +0800
-+++ numpy/numpy/distutils/system_info.py	2018-03-04 13:26:52.000000000 +0800
-@@ -1549,7 +1549,9 @@
-         if not atlas_info:
-             atlas_info = get_info('atlas')
- 
--        if sys.platform == 'darwin' and not (atlas_info or openblas_info or
-+        if sys.platform == 'darwin' \
-+                and not os.getenv('_PYTHON_HOST_PLATFORM', None) \
-+                and not (atlas_info or openblas_info or
-                                              lapack_mkl_info):
-             # Use the system lapack from Accelerate or vecLib under OSX
-             args = []
-@@ -1655,7 +1657,9 @@
-         if not atlas_info:
-             atlas_info = get_info('atlas_blas')
- 
--        if sys.platform == 'darwin' and not (atlas_info or openblas_info or
-+        if sys.platform == 'darwin' \
-+                and not os.getenv('_PYTHON_HOST_PLATFORM', None) \
-+                and not (atlas_info or openblas_info or
-                                              blas_mkl_info or blis_info):
-             # Use the system BLAS from Accelerate or vecLib under OSX
-             args = []
-diff -Nru numpy-1.14.1/numpy/linalg/lapack_lite/f2c.h numpy/numpy/linalg/lapack_lite/f2c.h
---- numpy-1.14.1/numpy/linalg/lapack_lite/f2c.h	2018-02-20 07:16:17.000000000 +0800
-+++ numpy/numpy/linalg/lapack_lite/f2c.h	2018-03-04 16:12:26.000000000 +0800
-@@ -7,6 +7,8 @@
- #ifndef F2C_INCLUDE
- #define F2C_INCLUDE
- 
-+#include <math.h>
-+
- typedef int integer;
- typedef char *address;
- typedef short int shortint;
---- numpy-1.14.1/numpy/core/src/private/npy_config.h   2018-10-20 19:30:37.000000000 +0200
-+++ numpy/numpy/core/src/private/npy_config.h  2018-10-20 20:13:35.000000000 +0200
+diff -Nru numpy-1.16.3/numpy/core/src/common/npy_config.h numpy/numpy/core/src/common/npy_config.h
+--- numpy-1.16.3/numpy/core/src/common/npy_config.h 2019-02-22 01:33:41.000000000 +0100
++++ numpy/numpy/core/src/common/npy_config.h    2019-04-26 16:36:26.000000000 +0200
 @@ -6,6 +6,17 @@
  #include "numpy/npy_cpu.h"
  #include "numpy/npy_os.h"
@@ -90,17 +16,20 @@ diff -Nru numpy-1.14.1/numpy/linalg/lapack_lite/f2c.h numpy/numpy/linalg/lapack_
 +#undef HAVE_SYS_ENDIAN_H
 +#undef HAVE_ENDIAN_H
 +
- /*
-  * largest alignment the copy loops might require
-  * required as string, void and complex types might get copied using larger
---- numpy-1.14.1/numpy/core/src/private/npy_fpmath.h   2018-02-05 02:21:37.000000000 +0100
-+++ numpy/numpy/core/src/private/npy_fpmath.h  2018-10-20 18:59:59.000000000 +0200
-@@ -44,7 +44,8 @@
+ /* blacklist */
+ 
+ /* Disable broken Sun Workshop Pro math functions */
+diff -Nru numpy-1.16.3/numpy/core/src/common/npy_fpmath.h numpy/numpy/core/src/common/npy_fpmath.h
+--- numpy-1.16.3/numpy/core/src/common/npy_fpmath.h 2019-02-22 01:33:41.000000000 +0100
++++ numpy/numpy/core/src/common/npy_fpmath.h    2019-04-26 17:14:16.000000000 +0200
+@@ -15,7 +15,9 @@
        defined(HAVE_LDOUBLE_INTEL_EXTENDED_12_BYTES_LE) || \
        defined(HAVE_LDOUBLE_MOTOROLA_EXTENDED_12_BYTES_BE) || \
-       defined(HAVE_LDOUBLE_DOUBLE_DOUBLE_BE) || \
--      defined(HAVE_LDOUBLE_DOUBLE_DOUBLE_LE))
-+      defined(HAVE_LDOUBLE_DOUBLE_DOUBLE_LE) ||\
-+      defined(__aarch64__)) /* Cross compiling for ARM64 (which has long double support) on macOS */
+       defined(HAVE_LDOUBLE_IBM_DOUBLE_DOUBLE_BE) || \
+-      defined(HAVE_LDOUBLE_IBM_DOUBLE_DOUBLE_LE))
++      defined(HAVE_LDOUBLE_IBM_DOUBLE_DOUBLE_LE) || \
++      defined(__aarch64__))
++      /* Cross compiling for ARM64 (which has long double support) on macOS */
      #error No long double representation defined
  #endif
+ 

--- a/patch/numpy/numpy.patch
+++ b/patch/numpy/numpy.patch
@@ -39,50 +39,6 @@ diff -Nru numpy-1.14.1/numpy/core/src/multiarray/strfuncs.c numpy/numpy/core/src
 diff -Nru numpy-1.14.1/numpy/distutils/system_info.py numpy/numpy/distutils/system_info.py
 --- numpy-1.14.1/numpy/distutils/system_info.py	2018-02-21 01:46:17.000000000 +0800
 +++ numpy/numpy/distutils/system_info.py	2018-03-04 13:26:52.000000000 +0800
-@@ -219,21 +219,21 @@
-     _lib_dirs = [
-         'lib',
-     ]
--    
-+
-     _include_dirs = [d.replace('/', os.sep) for d in _include_dirs]
-     _lib_dirs = [d.replace('/', os.sep) for d in _lib_dirs]
-     def add_system_root(library_root):
-         """Add a package manager root to the include directories"""
-         global default_lib_dirs
-         global default_include_dirs
--        
-+
-         library_root = os.path.normpath(library_root)
-- 
-+
-         default_lib_dirs.extend(
-             os.path.join(library_root, d) for d in _lib_dirs)
-         default_include_dirs.extend(
-             os.path.join(library_root, d) for d in _include_dirs)
--    
-+
-     if sys.version_info >= (3, 3):
-         # VCpkg is the de-facto package manager on windows for C/C++
-         # libraries. If it is on the PATH, then we append its paths here.
-@@ -247,7 +247,7 @@
-             else:
-                 specifier = 'x64'
- 
--            vcpkg_installed = os.path.join(vcpkg_dir, 'installed') 
-+            vcpkg_installed = os.path.join(vcpkg_dir, 'installed')
-             for vcpkg_root in [
-                 os.path.join(vcpkg_installed, specifier + '-windows'),
-                 os.path.join(vcpkg_installed, specifier + '-windows-static'),
-@@ -260,7 +260,7 @@
-             conda_dir = os.path.dirname(conda)
-             add_system_root(os.path.join(conda_dir, '..', 'Library'))
-             add_system_root(os.path.join(conda_dir, 'Library'))
--                        
-+
- else:
-     default_lib_dirs = libpaths(['/usr/local/lib', '/opt/lib', '/usr/lib',
-                                  '/opt/local/lib', '/sw/lib'], platform_bits)
 @@ -1549,7 +1549,9 @@
          if not atlas_info:
              atlas_info = get_info('atlas')

--- a/patch/numpy/numpy.patch
+++ b/patch/numpy/numpy.patch
@@ -117,3 +117,14 @@ diff -Nru numpy-1.14.1/numpy/linalg/lapack_lite/f2c.h numpy/numpy/linalg/lapack_
  typedef int integer;
  typedef char *address;
  typedef short int shortint;
+--- numpy-1.14.1/numpy/core/src/private/npy_config.h   2018-10-20 17:29:21.000000000 +0200
++++ numpy/numpy/core/src/private/npy_config copy.h  2018-10-20 17:31:20.000000000 +0200
+@@ -91,7 +91,7 @@
+ #if defined(HAVE_POWL) && defined(NPY_OS_DARWIN)
+ #undef HAVE_POWL
+ #endif
+-
++#undef HAVE_FEATURES_H
+ /* Disable broken gnu trig functions */
+ #if defined(HAVE_FEATURES_H)
+ #include <features.h>


### PR DESCRIPTION
This pull request enables bitcode for all Python 3.6 builds and supporting libs. It further focuses on enabling numpy 1.16.3 on iOS and was tested on actual devices and the simulator.

# Trivia
- enabling bitcode for iOS projects is default, but not mandatory.
- when the according XCode setting is enabled, the given python + numpy builds will not run on actual devices (simulator works, though) 
- when the fembed-bitcode flag is set, the given build process breaks
- linker flags such as `dyanmic_lookup` and `bundle` won't work anymore
- numpy 1.16.3 contains @freakboy3742 's [upstream patch for cross compilation](https://github.com/numpy/numpy/pull/10689)

# Approach
- `-fembed-bitcode` was enabled for all iOS builds
- environment variable `LDSHARED` used to further control cython numpy-build and linking
- linker flag `-undefined dyanmic_lookup` disabled: environment variable LDLIB was introduced to further control cython numpy-build and linking. Numpy was patched to recognize this non-std. variable. Std. variables (`LD_LIBRARY_PATH` and others) were not recognized by build script.
- linker flag `-undefined dyanmic_lookup` disabled: numpy was patched to name necessary libs.
- numpy random module was patched to circumvent runtime error that tries an local include of mtrand
- linker flag `- bundle` substituted with bitcode compatible flag `-r`.
- numpy startup/inclusion method was altered, due to merge of multiarray and umath (see README.rst)
- build target `dist/{iOS/tvOS/watchOS}/app_packages/numpy` introduced

# Todo
- [ ] check, review, discuss, enhance presented approach
- [ ] check warnings and error that are thrown when building numpy-iOS (skim for major flaws/problems)
- [ ] remove `-Wall` compile flag [here](https://github.com/beeware/Python-Apple-support/pull/72/files#diff-d6483f4066d0d05899b1e94e4d3468efR19)
- [ ] undo bzip-url commit
- [ ] re-enable and test macOS/tvOS/watchOS build

For our build the following platforms were selected (`makefile`)
```
# Supported OS
# OS=macOS iOS tvOS watchOS
# limit build to macOS iOS
OS=macOS iOS
```
