### PR TITLE
Don't exclude lib-dynload .so files. _posixshmem is required for multiprocessing

### DIFF
--- a/patch/Python/release.common.exclude
+++ b/patch/Python/release.common.exclude
@@ -17,8 +17,6 @@ Python/Resources/lib/python*/distutils/tests
 Python/Resources/lib/python*/lib2to3/tests
 Python/Resources/lib/python*/sqlite3/test
 Python/Resources/lib/python*/test
-# Remove compiled test and example modules.
-Python/Resources/lib/python*/lib-dynload/*.so
 # Remove config-* directory, which is used for compiling C extension modules.
 Python/Resources/lib/python*/config-*
 # Remove ensurepip. If user code needs pip, it can add it to


### PR DESCRIPTION
<!--- Describe your changes in detail -->

This removes the exclude of `lib-dynload` when generating the tarball.
<!--- What problem does this change solve? -->
Currently The `multiprocessing` module fails to load as all shared objects from `lib-dynload` are excluded from the distribution tarball. There is a `_posixshmem` module in this path that is imported by multiprocessing.
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x] All new features have been tested
- [ x] All new features have been documented
- [ x] I have read the **CONTRIBUTING.md** file
- [ x] I will abide by the code of conduct
