### PR TITLE
Numpy Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,12 @@
 Python Apple Support
 ====================
 
+**THIS IS AN ARCHIVE OF AN OLD STATE OF THE PROJECT**
+In March 2022, the decision was made to deprecate the tooling in this
+support package that allowed for the building of NumPy as a binary library.
+This tooling was error prone, and was not kept up to date. A more
+comprehensive approach for supporting binaries dependencies is required.
+
 **This repository branch builds a packaged version of Python 3.10.0**.
 Other Python versions are available by cloning other branches of the main
 repository.


### PR DESCRIPTION
This isn't so much a PR as an archive of an old state of the project, archived in case it is useful.

Prior to March 2022, this support package supported Numpy as a build artefact. However, this tooling was error prone, and was not kept up to date. A more comprehensive approach for supporting binaries dependencies is required.

THIS BRANCH IS NOT OFFICIALLY SUPPORTED. Bugs in numpy support generated by this PR/branch will not be considered to be bugs in the project as a whole. This branch is provided purely for educational purposes, in case it's useful for someone else.

If you want to use this branch, start with [this branch](https://github.com/beeware/Python-Apple-support/tree/numpy-support). However, when it breaks, you get to keep all the shiny pieces.