### PR TITLE
Include curses modules in macOS build

### DIFF
--- a/patch/Python/Setup.macOS
+++ b/patch/Python/Setup.macOS
@@ -34,3 +34,7 @@ _decimal _decimal/_decimal.c \
     -DCONFIG_64=1 -DANSI=1 -DHAVE_UINT128_T=1
 
 _scproxy _scproxy.c -framework SystemConfiguration -framework CoreFoundation
+
+_curses _cursesmodule.c -lcurses -ltermcap
+
+_curses_panel _curses_panel.c -lpanel -lncurses


### PR DESCRIPTION
This is a second try at #109, this time by including the curses modules in the static build instead of relying on the .so files in lib-dynload. Note that they are only included in macOS builds where the curses library is provided by the OS. Including curses modules on other platforms would not make such sense.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
