### PR TITLE
Support PATH variables with spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -718,7 +718,7 @@ $$(LIBFFI_DIR-$(os))/darwin_common/include/ffi.h: downloads/libffi-$(LIBFFI_VERS
 	cd $$(LIBFFI_DIR-$(os)) && patch -p1 < $(PROJECT_DIR)/patch/libffi.patch
 	# Configure the build
 	cd $$(LIBFFI_DIR-$(os)) && \
-		PATH=$(PROJECT_DIR)/$(PYTHON_DIR-macOS)/_install/bin:$(PATH) \
+		PATH="$(PROJECT_DIR)/$(PYTHON_DIR-macOS)/_install/bin:$(PATH)" \
 		python$(PYTHON_VER) generate-darwin-source-and-headers.py --only-$(shell echo $(os) | tr '[:upper:]' '[:lower:]') \
 		2>&1 | tee -a ../libffi-$(os).config.log
 


### PR DESCRIPTION
Without this change, `make iOS` and similar will fail when there's a space in PATH:
```
# Configure the build
cd build/iOS/libffi-3.4.2 && PATH=/Users/ambv/Dropbox/Python/Python-Apple-support/build/macOS/Python-3.11.0b1-macOS/_install/bin:/Users/ambv/.pyenv/shims:/Users/ambv/Library/Application Support/edgedb/bin:/Users/ambv/.dot_files/bin:/Users/ambv/.poetry/bin:/Users/ambv/.cargo/bin:/Users/ambv/.local/bin:/Library/TeX/texbin:/opt/homebrew/bin:/usr/local/opt/autoconf@2.69/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Library/TeX/texbin:/Users/ambv/opt/anaconda3/condabin python3.11 generate-darwin-source-and-headers.py --only-ios 2>&1 | tee -a ../libffi-iOS.config.log
/bin/sh: Support/edgedb/bin:/Users/ambv/.dot_files/bin:/Users/ambv/.poetry/bin:/Users/ambv/.cargo/bin:/Users/ambv/.local/bin:/Library/TeX/texbin:/opt/homebrew/bin:/usr/local/opt/autoconf@2.69/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Library/TeX/texbin:/Users/ambv/opt/anaconda3/condabin: No such file or directory
>>> Build libFFI for iphoneos.arm64
cd build/iOS/libffi-3.4.2/build_iphoneos-arm64 && make 2>&1 | tee -a ../../libffi-iphoneos.arm64.build.log
/bin/sh: line 0: cd: build/iOS/libffi-3.4.2/build_iphoneos-arm64: No such file or directory
make: *** [build/iOS/libffi-3.4.2/build_iphoneos-arm64/.libs/libffi.a] Error 1
```

Spaces are valid characters in PATH.

## PR Checklist:
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
