### PR TITLE
Update to build Python 3.11.0rc1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ BUILD_NUMBER=custom
 # PYTHON_VERSION is the full version number (e.g., 3.10.0b3)
 # PYTHON_MICRO_VERSION is the full version number, without any alpha/beta/rc suffix. (e.g., 3.10.0)
 # PYTHON_VER is the major/minor version (e.g., 3.10)
-PYTHON_VERSION=3.11.0b5
+PYTHON_VERSION=3.11.0rc1
 PYTHON_MICRO_VERSION=$(shell echo $(PYTHON_VERSION) | grep -Eo "\d+\.\d+\.\d+")
 PYTHON_VER=$(basename $(PYTHON_VERSION))
 
@@ -454,7 +454,7 @@ $$(PYTHON_DIR-$(target))/Makefile: \
 $$(PYTHON_DIR-$(target))/python.exe: $$(PYTHON_DIR-$(target))/Makefile
 	@echo ">>> Build Python for $(target)"
 	cd $$(PYTHON_DIR-$(target)) && \
-		make all \
+		make CFLAGS='-I../openssl/$$(SDK-$(target))/include -I../xz/$$(SDK-$(target))/include -I$$(SDK_ROOT-$(target))/usr/include/ffi' all \
 		2>&1 | tee -a ../python-$(target).build.log
 
 $$(PYTHON_LIB-$(target)): $$(PYTHON_DIR-$(target))/python.exe
@@ -801,7 +801,7 @@ $$(PYTHON_DIR-$(os))/python.exe: \
 	@echo ">>> Build Python for $(os)"
 	cd $$(PYTHON_DIR-$(os)) && \
 		PATH="$(PROJECT_DIR)/$(PYTHON_DIR-$(os))/_install/bin:$(PATH)" \
-		make all \
+		make CFLAGS='-I../openssl/$$(SDK-$(target))/include -I../xz/$$(SDK-$(target))/include -I$$(SDK_ROOT-$(target))/usr/include/fii' all \
 		2>&1 | tee -a ../python-$(os).build.log
 
 $$(PYTHON_LIB-$(os)): $$(PYTHON_DIR-$(os))/python.exe

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Python Apple Support
 ====================
 
-**This repository branch builds a packaged version of Python 3.11.0b1**.
+**This repository branch builds a packaged version of Python 3.11.0rc1**.
 Other Python versions are available by cloning other branches of the main
 repository.
 


### PR DESCRIPTION
Creating a draft PR to build [Python 3.11.0rc1](https://github.com/python/cpython/releases/tag/v3.11.0rc1).

Unfortunately the `update-patch` target fails for me with `fatal: ambiguous argument '3.11': unknown revision or path not in the working tree.`

I'm running `make` and `filterdiff` in a [Nix shell](https://nixos.org/manual/nix/unstable/command-ref/nix-shell.html) on macOS 12.5.
```
% make PATH=$PATH:~/.nixpkgs/bin PYTHON_REPO_DIR=~/Developer/cpython update-patch
# Generate a diff from the clone of the python/cpython Github repository
# Requires patchutils (installable via `brew install patchutils`); this
# also means we need to re-introduce homebrew to the path for the filterdiff
# call
if [ -z "~/Developer/cpython" ]; then echo "\n\nPYTHON_REPO_DIR must be set to the root of your Python github checkout\n\n"; fi
cd ~/Developer/cpython && \
		git diff -D v3.11.0rc1 3.11 \
			| PATH="/usr/local/bin:/opt/homebrew/bin:/nix/store/j8bgqi036m919jdq6jh3pgzhsxkfljyc-bash-interactive-5.1-p16/bin:/nix/store/griqc100a3gc6b2z1ydx5zh97zmqbnvi-clang-wrapper-11.1.0/bin:/nix/store/pf675gf1xkqijv8h59h6affv53i1z71d-clang-11.1.0/bin:/nix/store/1wrxx15a7hkihn77x77yip24q3jbxj44-coreutils-9.1/bin:/nix/store/5dd507hqqyycvfpyh3il8hg9phihx6h9-cctools-binutils-darwin-wrapper-949.0.1/bin:/nix/store/wwjnb39k76dkcdlzmxnx3m9y3c9dday0-cctools-binutils-darwin-949.0.1/bin:/nix/store/ji62hwfs4lx6xplxz7375ysg79ygpwv4-patchutils-0.3.4/bin:/nix/store/wixl30xvhyscyvpvw9mqivg2g9fks61g-findutils-4.9.0/bin:/nix/store/chwi9awr8iq49q1182sg7m9vkg46h5w0-diffutils-3.8/bin:/nix/store/vyv6i279bzml70fhqn1xdafbid7zsyg8-gnused-4.8/bin:/nix/store/v66fs5i6ffb324frcd643pl5qvixff2d-gnugrep-3.7/bin:/nix/store/mrq5j52yrzjc2f100rk9d5fvpwiw78wq-gawk-5.1.1/bin:/nix/store/0a2bp2r4p8hypc141ynd2hnjn8yv6v73-gnutar-1.34/bin:/nix/store/fppqa89mnk9844y1kggxyhxvgdfnw2zx-gzip-1.12/bin:/nix/store/dapph532rxhj49hmjknszvgayg7mvr0m-bzip2-1.0.8-bin/bin:/nix/store/da86m71jmmjw31xflgn53pqszhr4zxl8-gnumake-4.3/bin:/nix/store/7k3nqj8bpmpsk5vf8933hvs12q9307vc-bash-5.1-p16/bin:/nix/store/nmcvjgfvvwkgz39gnqqvyjx0nrrsga6d-patch-2.7.6/bin:/nix/store/qh4qpsbzv07a9lxvwiwnzi11hb48k7ds-xz-5.2.5-bin/bin:/nix/store/nlsrh8kd4gip4aid96333i69nil31ycq-file-5.42/bin:/Users/afh/.nix-profile/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin:/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin:/Users/afh/Developer/go/bin:/Users/afh/.cargo/bin:/Users/afh/Developer/dotfiles/bin:~/.nixpkgs/bin" filterdiff \
				-X /Users/afh/Developer/Python-Apple-support/patch/Python/diff.exclude -p 1 --clean \
					> /Users/afh/Developer/Python-Apple-support/patch/Python/Python.patch

```

It seems the `update-patch` target is trying to get a diff from the latest version `3.11.0rc1` to a "base" version `3.11`, yet no such tag seems to exist in the Python repo 
```
git -C ~src/cpython tag | sort -V | ag 3.11
v3.11.0a1
v3.11.0a2
v3.11.0a3
v3.11.0a4
v3.11.0a5
v3.11.0a6
v3.11.0a7
v3.11.0b1
v3.11.0b2
v3.11.0b3
v3.11.0b4
v3.11.0b5
v3.11.0rc1
```

❓ What am I doing wrong?

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
⁉️ _Where can I read the code of conduct? I did found neither the conduct nor a link to it in this repo or on the [Beeware Contributing](https://beeware.org/contributing/) web-pages…_
