### PR TITLE
Enable docstrings in Python builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -564,7 +564,6 @@ $$(PYTHON_SRCDIR-$(target))/Makefile: \
 			--prefix="$$(PYTHON_INSTALL-$(target))" \
 			--enable-ipv6 \
 			--with-openssl="$$(OPENSSL_MERGE-$$(SDK-$(target)))" \
-			--without-doc-strings \
 			--without-ensurepip \
 			ac_cv_file__dev_ptmx=no \
 			ac_cv_file__dev_ptc=no \
@@ -780,7 +779,6 @@ $$(PYTHON_SRCDIR-$(sdk))/Makefile: \
 			--enable-universalsdk \
 			--with-openssl="$$(OPENSSL_MERGE-$(sdk))" \
 			--with-universal-archs=universal2 \
-			--without-doc-strings \
 			--without-ensurepip \
 			2>&1 | tee -a ../python-$(PYTHON_VERSION).config.log
 
@@ -1097,12 +1095,12 @@ Python-$(os): dist/Python-$(PYTHON_VER)-$(os)-support.$(BUILD_NUMBER).tar.gz
 clean-Python-$(os):
 	@echo ">>> Clean Python build products on $(os)"
 	rm -rf \
-		build/$(os)/*/python-$(PYTHON_VERSION) \
-		build/$(os)/*/python-$(PYTHON_VERSION).*.log \
-		install/$(os)/*/python-$(PYTHON_VERSION) \
-		install/$(os)/*/python-$(PYTHON_VERSION).*.log \
-		merge/$(os)/*/python-$(PYTHON_VERSION) \
-		merge/$(os)/*/python-$(PYTHON_VERSION).*.log \
+		build/$(os)/*/python-$(PYTHON_VER)* \
+		build/$(os)/*/python-$(PYTHON_VER)*.*.log \
+		install/$(os)/*/python-$(PYTHON_VER)* \
+		install/$(os)/*/python-$(PYTHON_VER)*.*.log \
+		merge/$(os)/*/python-$(PYTHON_VER)* \
+		merge/$(os)/*/python-$(PYTHON_VER)*.*.log \
 		support/$(os) \
 		support/*-$(os).*.log \
 		dist/Python-$(PYTHON_VER)-$(os)-*


### PR DESCRIPTION
It turns out docstrings aren't just there for users - they're used by the `inspect` module to determine the prototype of builtin methods (via the `__text_signature__` attribute, populated by the Argument Clinic).

This PR re-enables docstrings. It also modifies the Python clean command to ensure that build products from the same micro version are removed. Previously, Python3.11rc1 wasn't removed if you were building 3.11rc2. 

Fixes #165.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
