### PR TITLE
Disable use of .curlrc when downloading sources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ LIBFFI_VERSION=3.4.2
 DEPENDENCIES=BZip2 XZ OpenSSL libFFI
 OS_LIST=macOS iOS tvOS watchOS
 
-CURL_FLAGS=--fail --location --create-dirs --progress-bar
+CURL_FLAGS=--disable --fail --location --create-dirs --progress-bar
 
 # macOS targets
 TARGETS-macOS=macosx.x86_64 macosx.arm64


### PR DESCRIPTION
from sourceforge.

<!--- Describe your changes in detail -->
<!--- What problem does this change solve? -->
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

I ran into issues with the Makefile when downloads xz, forward to and hosted on sourceforge, as the curl would download a HTML page instead of the source archive.
Adding a wget user-agent fixed the issue for me.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [ ] I will abide by the code of conduct
