### PR TITLE
Fixes regarding the apple store submission issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ wheels/*
 __pycache__
 tests/testbed/macOS
 tests/testbed/iOS
+*.log
+*.gz
+*.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -556,6 +556,8 @@ $$(PYTHON_SRCDIR-$(target))/Makefile: \
 			CXX="$$(CXX-$(target))" \
 			CFLAGS="$$(CFLAGS-$(target)) -I$$(BZIP2_MERGE-$$(SDK-$(target)))/include -I$$(XZ_MERGE-$$(SDK-$(target)))/include" \
 			LDFLAGS="$$(LDFLAGS-$(target)) -L$$(BZIP2_MERGE-$$(SDK-$(target)))/lib -L$$(XZ_MERGE-$$(SDK-$(target)))/lib" \
+			LDSHARED="$$(CC-$(target)) -dynamiclib -undefined dynamic_lookup" \
+			SHLIB_SUFFIX=".dylib" \
 			LIBFFI_INCLUDEDIR="$$(LIBFFI_MERGE-$$(SDK-$(target)))/include" \
 			LIBFFI_LIBDIR="$$(LIBFFI_MERGE-$$(SDK-$(target)))/lib" \
 			LIBFFI_LIB="ffi" \
@@ -772,6 +774,8 @@ $$(PYTHON_SRCDIR-$(sdk))/Makefile: \
 			CPP="$$(CPP-$(sdk))" \
 			CFLAGS="$$(CFLAGS-$(sdk)) -I$$(BZIP2_MERGE-$(sdk))/include -I$$(XZ_MERGE-$(sdk))/include" \
 			LDFLAGS="$$(LDFLAGS-$(sdk)) -L$$(XZ_MERGE-$(sdk))/lib -L$$(BZIP2_MERGE-$(sdk))/lib" \
+			LDSHARED="$$(CC-$(sdk)) -dynamiclib -undefined dynamic_lookup" \
+			SHLIB_SUFFIX=".dylib" \
 			--prefix="$$(PYTHON_INSTALL-$(sdk))" \
 			--enable-ipv6 \
 			--enable-universalsdk \
@@ -833,7 +837,7 @@ $$(PYTHON_FATINCLUDE-$(sdk)): $$(PYTHON_LIB-$(sdk))
 
 $$(PYTHON_FATSTDLIB-$(sdk)): $$(PYTHON_FATLIB-$(sdk))
 	@echo ">>> Build Python stdlib for the $(sdk) SDK"
-	mkdir -p $$(PYTHON_FATSTDLIB-$(sdk))
+	mkdir -p $$(PYTHON_FATSTDLIB-$(sdk))/lib-dynload
 	# Copy stdlib from the first target associated with the $(sdk) SDK
 	cp -r $$(PYTHON_INSTALL-$$(firstword $$(SDK_TARGETS-$(sdk))))/lib/python$(PYTHON_VER)/ $$(PYTHON_FATSTDLIB-$(sdk))
 

--- a/Makefile
+++ b/Makefile
@@ -1061,6 +1061,8 @@ $$(PYTHON_STDLIB-$(os)): \
 	# Copy the lib-dynload contents from every SDK in $(os) into the support folder.
 	$$(foreach sdk,$$(SDKS-$(os)),cp $$(PYTHON_FATSTDLIB-$$(sdk))/lib-dynload/* $$(PYTHON_STDLIB-$(os))/lib-dynload; )
 
+	cp $(PROJECT_DIR)/patch/Python/metapath-sitecustomize.py $$(PYTHON_STDLIB-$(os))/sitecustomize.py
+
 dist/Python-$(PYTHON_VER)-$(os)-support.$(BUILD_NUMBER).tar.gz: $$(PYTHON_XCFRAMEWORK-$(os)) $$(PYTHON_STDLIB-$(os))
 	@echo ">>> Create VERSIONS file for $(os)"
 	echo "Python version: $(PYTHON_VERSION) " > support/$(os)/VERSIONS

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ repository:
 It works by downloading, patching, and building a fat binary of Python and
 selected pre-requisites, and packaging them as static libraries that can be
 incorporated into an XCode project. The binary modules in the Python standard
-library are statically compiled, but are distribted as ``.so`` objects that
+library are statically compiled, but are distribted as ``.dylib`` objects that
 can be dynamically loaded at runtime.
 
 It exposes *almost* all the modules in the Python standard library except for:

--- a/patch/Python/Python.patch
+++ b/patch/Python/Python.patch
@@ -1,3 +1,22 @@
+--- a/Python/dynload_shlib.c
++++ b/Python/dynload_shlib.c
+@@ -38,12 +38,13 @@
+ #ifdef __CYGWIN__
+     ".dll",
+ #else  /* !__CYGWIN__ */
+-    "." SOABI ".so",
++    "." SOABI ".so", "." SOABI ".dylib",
+ #ifdef ALT_SOABI
+-    "." ALT_SOABI ".so",
++    "." ALT_SOABI ".so", "." ALT_SOABI ".dylib",
+ #endif
+     ".abi" PYTHON_ABI_STRING ".so",
+-    ".so",
++    ".abi" PYTHON_ABI_STRING ".dylib",
++    ".so", ".dylib",
+ #endif  /* __CYGWIN__ */
+     NULL,
+ };
 --- /dev/null
 +++ b/Lib/_ios_support.py
 @@ -0,0 +1,36 @@
@@ -2010,12 +2029,12 @@ index a0cb605c16..838641f649 100644
  
      def test_pep263(self):
          self.assertEqual(
--            "Питон".encode("utf-8"),
+-            "О©╫О©╫О©╫О©╫О©╫".encode("utf-8"),
 +            "О©╫О©╫О©╫О©╫О©╫".encode("utf-8"),
              b'\xd0\x9f\xd0\xb8\xd1\x82\xd0\xbe\xd0\xbd'
          )
          self.assertEqual(
--            "\П".encode("utf-8"),
+-            "\О©╫".encode("utf-8"),
 +            "\О©╫".encode("utf-8"),
              b'\\\xd0\x9f'
          )

--- a/patch/Python/Python.patch
+++ b/patch/Python/Python.patch
@@ -2029,13 +2029,13 @@ index a0cb605c16..838641f649 100644
  
      def test_pep263(self):
          self.assertEqual(
--            "�����".encode("utf-8"),
-+            "�����".encode("utf-8"),
+-            "ðÉÔÏÎ".encode("utf-8"),
++            "ï¿½ï¿½ï¿½ï¿½ï¿½".encode("utf-8"),
              b'\xd0\x9f\xd0\xb8\xd1\x82\xd0\xbe\xd0\xbd'
          )
          self.assertEqual(
--            "\�".encode("utf-8"),
-+            "\�".encode("utf-8"),
+-            "\ð".encode("utf-8"),
++            "\ï¿½".encode("utf-8"),
              b'\\\xd0\x9f'
          )
  

--- a/patch/Python/Python.patch
+++ b/patch/Python/Python.patch
@@ -2025,20 +2025,6 @@ index a0cb605c16..838641f649 100644
  from test.support.os_helper import TESTFN, unlink, rmtree
  from test.support.import_helper import unload
  import importlib
-@@ -14,11 +14,11 @@
- 
-     def test_pep263(self):
-         self.assertEqual(
--            "ðÉÔÏÎ".encode("utf-8"),
-+            "ï¿½ï¿½ï¿½ï¿½ï¿½".encode("utf-8"),
-             b'\xd0\x9f\xd0\xb8\xd1\x82\xd0\xbe\xd0\xbd'
-         )
-         self.assertEqual(
--            "\ð".encode("utf-8"),
-+            "\ï¿½".encode("utf-8"),
-             b'\\\xd0\x9f'
-         )
- 
 @@ -65,6 +65,7 @@
          # two bytes in common with the UTF-8 BOM
          self.assertRaises(SyntaxError, eval, b'\xef\xbb\x20')

--- a/patch/Python/metapath-sitecustomize.py
+++ b/patch/Python/metapath-sitecustomize.py
@@ -1,0 +1,39 @@
+import os
+import re
+import sys
+from importlib.abc import MetaPathFinder
+from importlib.machinery import EXTENSION_SUFFIXES, ExtensionFileLoader
+from importlib.util import spec_from_loader
+from pathlib import Path
+
+Frameworks_loc = Path(sys.executable).parent / "Frameworks"
+
+filename_extension = [x for x in EXTENSION_SUFFIXES if bool(re.search(r"\.cpython.*dylib", x))][0]
+
+
+class MyMetaPathFinder(MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if path is None or path == "":
+            path = [
+                os.getcwd(),
+            ]  # top level import
+
+        if "." in fullname:
+            *parents, name = fullname.split(".")
+        else:
+            name = fullname
+
+        for entry in path:
+            py_file_name = os.path.join(entry, name + ".py")
+            if os.path.exists(py_file_name):
+                return None
+
+        file_abs_path = os.path.join(Frameworks_loc, name + ".framework", name + filename_extension)
+        if os.path.exists(file_abs_path):
+            loader = ExtensionFileLoader(fullname, file_abs_path)
+            return spec_from_loader(fullname, loader)
+        else:
+            return None
+
+
+sys.meta_path.insert(0, MyMetaPathFinder())


### PR DESCRIPTION
In order to fix [apple-store-issue](https://github.com/beeware/Python-Apple-support/issues/176) we need to compile binary files into dynamic libraries (`.dylibs` instead of `.so`)
Also needed to modify `dynload_shlib.c` so python can read `.dylib`
Moreover, I have an issue compiling/patching `test_source_encoding.py` so I removed that from the patch. Also, I noticed that patch does not exist in the python3.11



## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
