### PR TITLE
Upgrade `upload-artifact` and `download-artifact` actions to v4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: macOS-latest
     outputs:
       TAG: ${{ steps.build-vars.outputs.TAG }}
@@ -21,26 +22,23 @@ jobs:
       OPENSSL_VERSION: ${{ steps.version-details.outputs.OPENSSL_VERSION }}
     strategy:
       matrix:
-        target: ['macOS', 'iOS', 'tvOS', 'watchOS']
+        target: [ "macOS", "iOS", "tvOS", "watchOS" ]
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout
+      uses: actions/checkout@v4.1.1
 
-    - name: Set build variables
+    - name: Set Build Variables
       id: build-vars
       env:
         TAG_NAME: ${{ github.ref }}
       run: |
         export TAG=$(basename $TAG_NAME)
-        echo "TAG=${TAG}"
         export PYTHON_VER="${TAG%-*}"
         export BUILD_NUMBER="${TAG#*-}"
 
-        echo "PYTHON_VER=${PYTHON_VER}"
-        echo "BUILD_NUMBER=${BUILD_NUMBER}"
-
-        echo "TAG=${TAG}" >> ${GITHUB_OUTPUT}
-        echo "PYTHON_VER=${PYTHON_VER}" >> ${GITHUB_OUTPUT}
-        echo "BUILD_NUMBER=${BUILD_NUMBER}" >> ${GITHUB_OUTPUT}
+        echo "TAG=${TAG}" | tee -a ${GITHUB_OUTPUT}
+        echo "PYTHON_VER=${PYTHON_VER}" | tee -a ${GITHUB_OUTPUT}
+        echo "BUILD_NUMBER=${BUILD_NUMBER}" | tee -a ${GITHUB_OUTPUT}
 
     - name: Set up Python
       uses: actions/setup-python@v5.0.0
@@ -52,7 +50,7 @@ jobs:
         # Do the build for the requested target.
         make ${{ matrix.target }} BUILD_NUMBER=${{ steps.build-vars.outputs.BUILD_NUMBER }}
 
-    - name: Extract version details
+    - name: Extract Version Details
       id: version-details
       run: |
         export PYTHON_VERSION=$(grep "Python version:" support/${{ steps.build-vars.outputs.PYTHON_VER }}/${{ matrix.target }}/VERSIONS | cut -d " " -f 3)
@@ -61,34 +59,30 @@ jobs:
         export OPENSSL_VERSION=$(grep "OpenSSL:" support/${{ steps.build-vars.outputs.PYTHON_VER }}/${{ matrix.target }}/VERSIONS | cut -d " " -f 2)
         export LIBFFI_VERSION=$(grep "libFFI:" support/${{ steps.build-vars.outputs.PYTHON_VER }}/${{ matrix.target }}/VERSIONS | cut -d " " -f 2)
 
-        echo "PYTHON_VERSION=${PYTHON_VERSION}"
-        echo "BZIP2_VERSION=${BZIP2_VERSION}"
-        echo "XZ_VERSION=${XZ_VERSION}"
-        echo "OPENSSL_VERSION=${OPENSSL_VERSION}"
-        echo "LIBFFI_VERSION=${LIBFFI_VERSION}"
+        echo "PYTHON_VERSION=${PYTHON_VERSION}" | tee -a ${GITHUB_OUTPUT}
+        echo "BZIP2_VERSION=${BZIP2_VERSION}" | tee -a ${GITHUB_OUTPUT}
+        echo "XZ_VERSION=${XZ_VERSION}" | tee -a ${GITHUB_OUTPUT}
+        echo "OPENSSL_VERSION=${OPENSSL_VERSION}" | tee -a ${GITHUB_OUTPUT}
+        echo "LIBFFI_VERSION=${LIBFFI_VERSION}" | tee -a ${GITHUB_OUTPUT}
 
-        echo "PYTHON_VERSION=${PYTHON_VERSION}" >> ${GITHUB_OUTPUT}
-        echo "BZIP2_VERSION=${BZIP2_VERSION}" >> ${GITHUB_OUTPUT}
-        echo "XZ_VERSION=${XZ_VERSION}" >> ${GITHUB_OUTPUT}
-        echo "OPENSSL_VERSION=${OPENSSL_VERSION}" >> ${GITHUB_OUTPUT}
-        echo "LIBFFI_VERSION=${LIBFFI_VERSION}" >> ${GITHUB_OUTPUT}
-
-    - name: Upload build artifact
-      uses: actions/upload-artifact@v3.1.3
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v4.0.0
       with:
-        name: dist
-        path: "dist"
+        name: dist-${{ matrix.target }}
+        path: dist
         if-no-files-found: error
 
   make-release:
+    name: Make Release
     runs-on: ubuntu-latest
     needs: build
     steps:
     - name: Get build artifacts
-      uses: actions/download-artifact@v3.0.2
+      uses: actions/download-artifact@v4.1.0
       with:
-        name: dist
+        pattern: dist-*
         path: dist
+        merge-multiple: true
 
     - name: Create Release
       uses: ncipollo/release-action@v1.13.0


### PR DESCRIPTION
## Changes
- RE: https://github.com/beeware/.github/issues/77
- Bump `upload-artifact` and `download-artifact` actions to v4
- To accommodate v4:
  - Artifacts must have unique names since multiple uploads cannot contribute to a single artifact
  - Use a wildcard pattern to download all artifacts and merge in to a single directory

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [X] All new features have been documented
- [X] I have read the **CONTRIBUTING.md** file
- [X] I will abide by the code of conduct