### PR TITLE
Add disabling dead code stripping in linker

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -145,6 +145,9 @@ echo "Signing as $EXPANDED_CODE_SIGN_IDENTITY_NAME ($EXPANDED_CODE_SIGN_IDENTITY
 find "$CODESIGNING_FOLDER_PATH/Contents/Resources/python-stdlib/lib-dynload" -name "*.so" -exec /usr/bin/codesign --force --sign "$EXPANDED_CODE_SIGN_IDENTITY" -o runtime --timestamp=none --preserve-metadata=identifier,entitlements,flags --generate-entitlement-der {} \;
 ```
 
+8. Disable dead code removal. As of March 2024 Xcode has "Dead Code Stripping" enabled by default. This _will_ remove functions from linked Python library that linker found unused.
+   Navigate to Build Settings -> Linkin - General. Find "Dead Code Stripping" and select "No"
+
 You will now be able to access the Python runtime in your Python code.
 
 If you are on iOS, you will be able to deploy to an iOS simulator without specifying


### PR DESCRIPTION
Mention in the guide that embedding Python requires disabling dead code removal.

When attempting to embed Python as per `USAGE.md` people end up with non-working solution due to linker removing parts of embedded Python that it found unused. For example, importing `base64` fails due to inability to load `_PyFloat_Pack4`. 
<!--- If this PR relates to an issue, include Refs #XXX or Fixes #XXX -->

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
