### PR TITLE
Revert TODOs related to in-progress briefcase work.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,20 +131,15 @@ jobs:
       with:
         repository: beeware/Python-support-testbed
         path: Python-support-testbed
-        # TODO - remove the py3.13 reference option.
-        ref: py3.13-support
 
     - name: Install dependencies
       if: matrix.run-tests
       run: |
-        # TODO - Revert to the development version of Briefcase
         # Use the development version of Briefcase
-        # python -m pip install git+https://github.com/beeware/briefcase.git
-        python -m pip install git+https://github.com/freakboy3742/briefcase.git@version-bumps
+        python -m pip install git+https://github.com/beeware/briefcase.git
 
     - name: Run support testbed check
       if: matrix.run-tests
       timeout-minutes: 10
       working-directory: Python-support-testbed
-      # TODO - remove the template_branch option.
-      run: briefcase run ${{ matrix.target }} Xcode --test ${{ matrix.briefcase-run-args }} -C support_package=\'../dist/Python-${{ needs.config.outputs.PYTHON_VER }}-${{ matrix.target }}-support.${{ needs.config.outputs.BUILD_NUMBER }}.tar.gz\' -C template_branch=\'framework-lib\'
+      run: briefcase run ${{ matrix.target }} Xcode --test ${{ matrix.briefcase-run-args }} -C support_package=\'../dist/Python-${{ needs.config.outputs.PYTHON_VER }}-${{ matrix.target }}-support.${{ needs.config.outputs.BUILD_NUMBER }}.tar.gz\'


### PR DESCRIPTION
Now that the framework-based support is all in place, we can revert the TODOs that tied the usage of Briefcase to the in-progress branches.

This can't be merged until full binary support is restored to beeware/Python-support-testbed (see beeware/Python-support-testbed#49).

When this PR is merged, we can delete the branches associated with:
* beeware/briefcase-macOS-Xcode-template#47
* beeware/briefcase-macOS-app-template#64
* beeware/briefcase-iOS-Xcode-template#37
* beeware/briefcase#1934

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
