### PR TITLE
Add ios_ver and _multiarch shims for pip 24.3 support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,10 @@ ARCH-$(target)=$$(subst .,,$$(suffix $(target)))
 ifneq ($(os),macOS)
 	ifeq ($$(findstring simulator,$$(SDK-$(target))),)
 TARGET_TRIPLE-$(target)=$$(ARCH-$(target))-apple-$$(OS_LOWER-$(target))$$(VERSION_MIN-$(os))
+IS_SIMULATOR-$(target)="False"
 	else
 TARGET_TRIPLE-$(target)=$$(ARCH-$(target))-apple-$$(OS_LOWER-$(target))$$(VERSION_MIN-$(os))-simulator
+IS_SIMULATOR-$(target)="True"
 	endif
 endif
 
@@ -324,6 +326,9 @@ $$(PYTHON_SITECUSTOMIZE-$(target)):
 	cat $(PROJECT_DIR)/patch/Python/sitecustomize.$(os).py \
 		| sed -e "s/{{os}}/$(os)/g" \
 		| sed -e "s/{{arch}}/$$(ARCH-$(target))/g" \
+		| sed -e "s/{{version_min}}/$$(VERSION_MIN-$(os))/g" \
+		| sed -e "s/{{is_simulator}}/$$(IS_SIMULATOR-$(target))/g" \
+		| sed -e "s/{{multiarch}}/$$(ARCH-$(target))-$$(SDK-$(target))/g" \
 		| sed -e "s/{{tag}}/$$(OS_LOWER-$(target))-$$(VERSION_MIN-$(os))-$$(ARCH-$(target))-$$(SDK-$(target))/g" \
 		> $$(PYTHON_SITECUSTOMIZE-$(target))
 

--- a/patch/Python/sitecustomize.iOS.py
+++ b/patch/Python/sitecustomize.iOS.py
@@ -2,6 +2,7 @@
 # packages cross-platform. If the folder containing this file is on
 # your PYTHONPATH when you invoke pip, pip will behave as if it were
 # running on {{os}}.
+import collections
 import distutils.ccompiler
 import distutils.unixccompiler
 import os
@@ -16,7 +17,21 @@ def custom_system():
 
 platform.system = custom_system
 
-# Make sysconfig.get_platform() return "{{tag}}"
+# Make platform.ios_ver() return an appropriate namedtuple
+IOSVersionInfo = collections.namedtuple(
+    "IOSVersionInfo",
+    ["system", "release", "model", "is_simulator"]
+)
+
+def custom_ios_ver(system="", release="", model="", is_simulator=False):
+    return IOSVersionInfo("{{os}}", "{{version_min}}", "iPhone", {{is_simulator}})
+
+platform.ios_ver = custom_ios_ver
+
+# Make sys.implementation._multiarch return the multiarch description
+sys.implementation._multiarch = "{{multiarch}}"
+
+# Make sysconfig.get_platform() return the platform tag
 def custom_get_platform():
     return "{{tag}}"
 


### PR DESCRIPTION
Pip 24.3 includes explicit support for iOS as a platform; the sitecustomize shim provided by the support package triggers this handling. However, it then requires `platform.ios_ver()` and `sys.implementation._multiarch` to return the correct values to determine the tag name.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
