### PR TITLE
Improve support for PythonKit, and update usage guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,6 +466,9 @@ $$(PYTHON_INCLUDE-$(sdk))/pyconfig.h: $$(PYTHON_LIB-$(sdk))
 	# Copy headers as-is from the first target in the $(sdk) SDK
 	cp -r $$(PYTHON_INCLUDE-$$(firstword $$(SDK_TARGETS-$(sdk)))) $$(PYTHON_INCLUDE-$(sdk))
 
+	# Copy in the modulemap file
+	cp -r patch/Python/module.modulemap $$(PYTHON_INCLUDE-$(sdk))
+
 	# Link the PYTHONHOME version of the headers
 	mkdir -p $$(PYTHON_INSTALL-$(sdk))/include
 	ln -si ../Python.framework/Headers $$(PYTHON_INSTALL-$(sdk))/include/python$(PYTHON_VER)
@@ -581,6 +584,9 @@ $$(PYTHON_XCFRAMEWORK-$(os))/Info.plist: \
 
 	# Rewrite the framework to make it standalone
 	patch/make-relocatable.sh $$(PYTHON_INSTALL_VERSION-macosx) 2>&1 > /dev/null
+
+	# Copy in the modulemap file
+	cp -r patch/Python/module.modulemap $$(PYTHON_FRAMEWORK-macosx)/Headers
 
 	# Re-apply the signature on the binaries.
 	codesign -s - --preserve-metadata=identifier,entitlements,flags,runtime -f $$(PYTHON_LIB-macosx) \

--- a/patch/Python/module.modulemap
+++ b/patch/Python/module.modulemap
@@ -1,0 +1,5 @@
+module Python {
+    umbrella header "Python.h"
+    export *
+    link "Python"
+}


### PR DESCRIPTION
Fixes #234.

Adds a Swift modulemap to the generated frameworks, and updates the PythonKit usage guide to include the correct details on path information.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
