### PR TITLE
Preserve pyc files in distributed artefacts.

### DIFF
--- a/patch/Python/release.iOS.exclude
+++ b/patch/Python/release.iOS.exclude
@@ -1,3 +1,6 @@
 # This is a list of support package path patterns that we exclude
 # from all Python-Apple-support tarballs.
 # It is used by `tar -X` during the Makefile build.
+# Remove -opt-*.pyc files. These take up a lot of space, but won't be used for
+# most deployments.
+*.opt-*.pyc

--- a/patch/Python/release.iOS.exclude
+++ b/patch/Python/release.iOS.exclude
@@ -1,6 +1,3 @@
 # This is a list of support package path patterns that we exclude
 # from all Python-Apple-support tarballs.
 # It is used by `tar -X` during the Makefile build.
-# Remove pyc files. These take up space, but since most stdlib modules are
-# never imported by user code, they mostly have no value.
-*/__pycache__

--- a/patch/Python/release.tvOS.exclude
+++ b/patch/Python/release.tvOS.exclude
@@ -1,3 +1,6 @@
 # This is a list of support package path patterns that we exclude
 # from all Python-Apple-support tarballs.
 # It is used by `tar -X` during the Makefile build.
+# Remove -opt-*.pyc files. These take up a lot of space, but won't be used for
+# most deployments.
+*.opt-*.pyc

--- a/patch/Python/release.tvOS.exclude
+++ b/patch/Python/release.tvOS.exclude
@@ -1,6 +1,3 @@
 # This is a list of support package path patterns that we exclude
 # from all Python-Apple-support tarballs.
 # It is used by `tar -X` during the Makefile build.
-# Remove pyc files. These take up space, but since most stdlib modules are
-# never imported by user code, they mostly have no value.
-*/__pycache__

--- a/patch/Python/release.watchOS.exclude
+++ b/patch/Python/release.watchOS.exclude
@@ -1,3 +1,6 @@
 # This is a list of support package path patterns that we exclude
 # from all Python-Apple-support tarballs.
 # It is used by `tar -X` during the Makefile build.
+# Remove -opt-*.pyc files. These take up a lot of space, but won't be used for
+# most deployments.
+*.opt-*.pyc

--- a/patch/Python/release.watchOS.exclude
+++ b/patch/Python/release.watchOS.exclude
@@ -1,6 +1,3 @@
 # This is a list of support package path patterns that we exclude
 # from all Python-Apple-support tarballs.
 # It is used by `tar -X` during the Makefile build.
-# Remove pyc files. These take up space, but since most stdlib modules are
-# never imported by user code, they mostly have no value.
-*/__pycache__


### PR DESCRIPTION
Although PYC files were being stripped to save space, it turns out it's significantly faster at runtime to have PYCs cached for use. This removes the `__pycache__` exclusion from packaged artefacts.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
