### PR TITLE
Ensure base_prefix is set in a cross-venv.

### DIFF
--- a/patch/Python/_cross_target.py.tmpl
+++ b/patch/Python/_cross_target.py.tmpl
@@ -11,6 +11,8 @@ import sysconfig
 sys.cross_compiling = True
 sys.platform = "{{platform}}"
 sys.implementation._multiarch = "{{arch}}-{{sdk}}"
+sys.base_prefix = sysconfig.get_config_var("prefix")
+sys.base_exec_prefix = sysconfig.get_config_var("prefix")
 
 ###########################################################################
 # subprocess module patches
@@ -66,6 +68,10 @@ def cross_get_sysconfigdata_name():
 
 sysconfig.get_platform = cross_get_platform
 sysconfig._get_sysconfigdata_name = cross_get_sysconfigdata_name
+
+# Ensure module-level values cached at time of import are updated.
+sysconfig._BASE_PREFIX = sys.prefix
+sysconfig._BASE_EXEC_PREFIX = sys.base_exec_prefix
 
 # Force sysconfig data to be loaded (and cached).
 sysconfig._init_config_vars()


### PR DESCRIPTION
Updates the cross-venv script to ensure that the base_prefix is set correctly.

This then flows through to some of the paths in the `venv` scheme; without this patch, the `include` path will point a the location of the macOS interpreter running the cross-venv.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
