### PR TITLE
Correct handling of sysconfig._BASE_PREFIX in cross environments. (#297)

### DIFF
--- a/patch/Python/_cross_target.py.tmpl
+++ b/patch/Python/_cross_target.py.tmpl
@@ -70,7 +70,7 @@ sysconfig.get_platform = cross_get_platform
 sysconfig._get_sysconfigdata_name = cross_get_sysconfigdata_name
 
 # Ensure module-level values cached at time of import are updated.
-sysconfig._BASE_PREFIX = sys.prefix
+sysconfig._BASE_PREFIX = sys.base_prefix
 sysconfig._BASE_EXEC_PREFIX = sys.base_exec_prefix
 
 # Force sysconfig data to be loaded (and cached).


### PR DESCRIPTION
Ensure that sysconfig._BASE_PREFIX is bound to base_prefix, not prefix.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
