### PR TITLE
Update CI config to use macos-26.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,15 +100,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Xcode
-        # GitHub recommends explicitly selecting the desired Xcode version:
-        # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140
-        # This became a necessity as a result of
-        # https://github.com/actions/runner-images/issues/12541 and
-        # https://github.com/actions/runner-images/issues/12751.
-        run: |
-          sudo xcode-select --switch /Applications/Xcode_16.4.app
-
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
@@ -142,7 +133,7 @@ jobs:
           - briefcase-run-args:
 
           - platform: iOS
-            briefcase-run-args: ' -d "iPhone 16e::iOS 18.5"'
+            briefcase-run-args: ' -d "iPhone 17e::iOS 26.4"'
 
     steps:
       - uses: actions/checkout@v6
@@ -198,9 +189,9 @@ jobs:
         platform: ["iOS", "tvOS", "visionOS"]
         include:
           - platform: "iOS"
-            testbed-args: '--simulator "iPhone 16e,arch=arm64,OS=18.5"'
+            testbed-args: '--simulator "iPhone 17e,arch=arm64,OS=26.4"'
           - platform: "visionOS"
-            testbed-args: '--simulator "Apple Vision Pro,arch=arm64,OS=2.5"'
+            testbed-args: '--simulator "Apple Vision Pro,arch=arm64,OS=26.4"'
 
     steps:
       - uses: actions/checkout@v6
@@ -211,15 +202,6 @@ jobs:
           pattern: Python-${{ needs.config.outputs.PYTHON_VER }}-${{ matrix.platform }}-support.${{ needs.config.outputs.BUILD_NUMBER }}.tar.gz
           path: dist
           merge-multiple: true
-
-      - name: Set up Xcode
-        # GitHub recommends explicitly selecting the desired Xcode version:
-        # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140
-        # This became a necessity as a result of
-        # https://github.com/actions/runner-images/issues/12541 and
-        # https://github.com/actions/runner-images/issues/12751.
-        run: |
-          sudo xcode-select --switch /Applications/Xcode_16.4.app
 
       - name: Set up Python
         uses: actions/setup-python@v6.2.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ concurrency:
 
 jobs:
   config:
-    runs-on: macOS-latest
+    runs-on: macOS-26
     outputs:
       PYTHON_VER: ${{ steps.extract.outputs.PYTHON_VER }}
       PYTHON_VERSION: ${{ steps.extract.outputs.PYTHON_VERSION }}
@@ -90,7 +90,7 @@ jobs:
           echo "ZSTD_VERSION=${ZSTD_VERSION}" | tee -a ${GITHUB_OUTPUT}
 
   build:
-    runs-on: macOS-15
+    runs-on: macOS-26
     needs: [config]
     strategy:
       fail-fast: false
@@ -190,7 +190,7 @@ jobs:
 
   cpython-testbed:
     name: CPython testbed (${{ matrix.platform }})
-    runs-on: macOS-15
+    runs-on: macOS-26
     needs: [config, build]
     strategy:
       fail-fast: false
@@ -251,7 +251,7 @@ jobs:
 
   crossenv-test:
     name: Cross-platform env test (${{ matrix.multiarch }})
-    runs-on: macOS-latest
+    runs-on: macOS-26
     needs: [config, build]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
 
   briefcase-testbed:
     name: Briefcase testbed (${{ matrix.platform }})
-    runs-on: macOS-15
+    runs-on: macOS-26
     needs: [config, build]
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,15 +138,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Xcode
-        # GitHub recommends explicitly selecting the desired Xcode version:
-        # https://github.com/actions/runner-images/issues/12541#issuecomment-3083850140
-        # This became a necessity as a result of
-        # https://github.com/actions/runner-images/issues/12541 and
-        # https://github.com/actions/runner-images/issues/12751.
-        run: |
-          sudo xcode-select --switch /Applications/Xcode_16.4.app
-
       - name: Get build artifact
         uses: actions/download-artifact@v8.0.1
         with:
@@ -189,9 +180,9 @@ jobs:
         platform: ["iOS", "tvOS", "visionOS"]
         include:
           - platform: "iOS"
-            testbed-args: '--simulator "iPhone 17e,arch=arm64,OS=26.4"'
+            testbed-args: '--simulator "iPhone 17e,arch=arm64,OS=26.4.1"'
           - platform: "visionOS"
-            testbed-args: '--simulator "Apple Vision Pro,arch=arm64,OS=26.4"'
+            testbed-args: '--simulator "Apple Vision Pro,arch=arm64,OS=26.4.1"'
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
To ensure the most recent SDKs are in use, build using macOS-26.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
